### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://liorbanai.visualstudio.com/cfdbfc6d-fc58-4ccb-9602-29a268a27500/1d646dba-f625-4cd8-a98b-74f4ffa4301f/_apis/work/boardbadge/cd1bc44b-a694-4b14-b46d-0dcfc315a0b9)](https://liorbanai.visualstudio.com/cfdbfc6d-fc58-4ccb-9602-29a268a27500/_boards/board/t/1d646dba-f625-4cd8-a98b-74f4ffa4301f/Microsoft.RequirementCategory)
 # Hdf5DotnetWrapper   <img src="./Assets/hdf5Wrapper.png" align="right" width="155px" height="155px">
 Set of tools that help in reading and writing hdf5 files for .net environments
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://liorbanai.visualstudio.com/cfdbfc6d-fc58-4ccb-9602-29a268a27500/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.